### PR TITLE
Update gitmodule with http url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "coc/message"]
 	path = coc/message
-	url = git@github.com:royale-proxy/cr-messages-python.git
+	url = https://github.com/royale-proxy/cr-messages-python.git


### PR DESCRIPTION
Don't use the SSH url. It will break for people that don't have access to your repo. Use the http url.
